### PR TITLE
Added .slice() to the yData to get a deep copy of the array

### DIFF
--- a/export-csv.js
+++ b/export-csv.js
@@ -21,7 +21,7 @@
             columns[0].unshift("");
         }
         each (this.series, function (series) {
-            columns.push(series.yData);
+            columns.push(series.yData.slice());
             columns[columns.length - 1].unshift(series.name);
         });
         


### PR DESCRIPTION
### Why

As it stands, a shallow copy of series.yData gets pushed onto columns.  Then in the next line, series.name is added to the beginning.  This actually changes the yData array in series, so that (if it doesn't break the chart) the next time you run "Export CSV" there are n instances of series.name in the data where n = number of times you've exported to csv.
### What

Added the .slice() to the array to get a deep copy with a minimal amount of code.
