### PR TITLE
Exporting accentuated characters

### DIFF
--- a/export-csv.js
+++ b/export-csv.js
@@ -75,7 +75,7 @@
                 if (downloadAttrSupported) {
                     // Client side extraction
                     a = document.createElement('a');
-                    a.href		  = 'data:attachment/csv;charset=utf-8,%EF%BB%BF,' + this.getCSV().replace(/\n/g, '%0A');
+                    a.href		  = 'data:attachment/csv;charset=utf-8,%EF%BB%BF' + this.getCSV().replace(/\n/g, '%0A');
                     a.target      = '_blank';
                     a.download    = (this.title ? this.title.textStr.replace(/ /g, '-').toLowerCase() : 'chart') + '.csv';
                     document.body.appendChild(a);


### PR DESCRIPTION
This change fixes exporting accentuated characters like à á õ Ç (etc) that appear in series names in Windows Excel (tested).
