### PR TITLE
Sugestion

### DIFF
--- a/export-csv.js
+++ b/export-csv.js
@@ -55,6 +55,9 @@
             line = [];
             for (col = 0; col < columns.length; col = col + 1) {
                 line.push(columns[col][row]);
+                // Export Category column only once
+				if (col % 2 == 1)
+					col++;                
             }
             csv += line.join(itemDelimiter) + lineDelimiter;
         }


### PR DESCRIPTION
This change will export regular 2D charts as an Excel table without duplicated columns.
Unfortunately I believe this hack can not be applied to more complex chart types (more dimensions), but since I don't use those in my web site I didn't develop a generic fix.
I leave this piece of code here as food for thought. Thanks.
