### PR TITLE
Add CommonJS / NPM support

### DIFF
--- a/export-csv.js
+++ b/export-csv.js
@@ -6,7 +6,13 @@
  * Version:  1.3.8
  */
 /*global Highcharts, window, document, Blob */
-(function (Highcharts) {
+(function (factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory;
+    } else {
+        factory(Highcharts);
+    }
+})(function (Highcharts) {
 
     'use strict';
 
@@ -301,4 +307,4 @@
         });
     }
 
-}(Highcharts));
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "highcharts-export-csv",
+  "version": "1.3.8",
+  "description": "Highcharts plugin to export the chart data to CSV, XLS or HTML table",
+  "keywords": [
+    "export",
+    "csv",
+    "xls"
+  ],
+  "main": "export-csv.js",
+  "author": {
+    "name": "Torstein Hønsi",
+    "url": "https://github.com/highslide-software"
+  },
+  "contributors": [
+    {
+      "name": "Torgrim Thorsen",
+      "url": "https://github.com/SirAlexiner",
+      "email": "Sir_Alexiner@hotmail.com"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/highcharts/export-csv"
+  },
+  "peerDependencies": {
+    "highcharts": ">=3.0.0 <5.0.0"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/highcharts/export-csv/issues"
+  },
+  "homepage": "http://www.highcharts.com/plugin-registry/single/7/Export-CSV"
+}


### PR DESCRIPTION
This adds CommonJS support to this module by detecting the presence of `module.exports`, and if it exists, exporting the factory function instead of calling it on the global Highcharts object. This is in line with how the Highcharts exporting module is used in CommonJS.

It also adds a package.json, if this PR gets accepted please publish this module on NPM.
 - I prefixed the name with `highcharts-` since it is a plugin
 - I added highcharts as `peerDependency` since that is how version constraints for plugins should be defined. The [homepage](http://www.highcharts.com/plugin-registry/single/7/Export-CSV) mentions at least 3.0 is required, so I set the version constraint between 3.0 and the next major version.
 - I took the version from the manifest.json (1.3.8), even though the homepage actually says 1.3.6
 - I took the description from the homepage (first sentence)

This allows one to `require('highcharts-export-csv')(Highcharts)` in a CommonJS environment like Browerify. Global use is still supported.