### PR TITLE
Update bower.json to avoid problems with name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,24 @@
 {
-  "name": "Highcharts export-csv plugin",
+  "name": "export-csv",
+  "version": "1.3.8",
+  "description": "Highcharts plugin to export the chart data to CSV, XLS or HTML table",
+  "keywords": [
+    "export",
+    "csv",
+    "xls"
+  ],
+  "authors": [
+    { "name": "Torstein Hønsi", "homepage": "https://github.com/highslide-software" }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/highcharts/export-csv"
+  },
   "main": "export-csv.js",
   "license": "MIT",
   "ignore": [
     "**/.*",
     "README.md"
-  ]
+  ],
+  "homepage": "http://www.highcharts.com/plugin-registry/single/7/Export-CSV"
 }


### PR DESCRIPTION
Add informations in bower.json to avoid registry name problems.
After install, export-csv was registered in bower.json as :
````json
"Highcharts export-csv plugin": "export-csv#*"
````
- wrong registry name and version cause errors using bower for any task (ex: `bower install`) : 
````
bower                        ENOTFOUND Package Highcharts export-csv plugin=export-csv not found
````

You also need to create git tags with versions ! See https://github.com/highcharts/export-csv/issues/69 for more info.
