### PR TITLE
String crush issue on MS Excel

### DIFF
--- a/export-csv.js
+++ b/export-csv.js
@@ -261,7 +261,7 @@
         var csv = this.getCSV(true);
         getContent(
             this,
-            'data:text/csv,' + csv.replace(/\n/g, '%0A'),
+            'data:text/csv,\uFEFF' + csv.replace(/\n/g, '%0A'),
             'csv',
             csv,
             'text/csv'


### PR DESCRIPTION
String(i'm Korean) crush issue solution on MS Excel(CSV).
Excel ignored the charset=UTF-8 part, force Excel to take into account the UTF-8. So this last line did the trick
Reference: http://stackoverflow.com/questions/155097/microsoft-excel-mangles-diacritics-in-csv-files

Thank you :D