### PR TITLE
New options

### DIFF
--- a/export-csv.js
+++ b/export-csv.js
@@ -27,7 +27,8 @@
             downloadXLS: 'Download XLS',
             viewData: 'View data table',
             xTitleCategoryExport: 'Category',   // used if xAxis is without title (Category axis)
-            xTitleDateTimeExport: 'DateTime'    // used if xAxis is without title (DateTime axis)
+            xTitleDateTimeExport: 'DateTime',   // used if xAxis is without title (DateTime axis)
+            xlsWorksheetName: 'Ark1'
         }
     });
 
@@ -281,7 +282,7 @@
         var uri = 'data:application/vnd.ms-excel;base64,',
             template = '<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40">' +
                 '<head><!--[if gte mso 9]><xml><x:ExcelWorkbook><x:ExcelWorksheets><x:ExcelWorksheet>' +
-                '<x:Name>Ark1</x:Name>' +
+                '<x:Name>' + Highcharts.getOptions().lang.xlsWorksheetName + '</x:Name>' +
                 '<x:WorksheetOptions><x:DisplayGridlines/></x:WorksheetOptions></x:ExcelWorksheet></x:ExcelWorksheets></x:ExcelWorkbook></xml><![endif]-->' +
                 '<style>td{border:none;font-family: Calibri, sans-serif;} .number{mso-number-format:"0.00";}</style>' +
                 '<meta name=ProgId content=Excel.Sheet>' +

--- a/export-csv.js
+++ b/export-csv.js
@@ -25,7 +25,9 @@
         lang: {
             downloadCSV: 'Download CSV',
             downloadXLS: 'Download XLS',
-            viewData: 'View data table'
+            viewData: 'View data table',
+            xTitleCategoryExport: 'Category',   // used if xAxis is without title (Category axis)
+            xTitleDateTimeExport: 'DateTime'    // used if xAxis is without title (DateTime axis)
         }
     });
 
@@ -114,7 +116,7 @@
 
         // Add header row
         if (!xTitle) {
-            xTitle = xAxis.isDatetimeAxis ? 'DateTime' : 'Category';
+            xTitle = xAxis.isDatetimeAxis ? Highcharts.getOptions().lang.xTitleDateTimeExport : Highcharts.getOptions().lang.xTitleCategoryExport;
         }
         dataRows = [[xTitle].concat(names)];
 


### PR DESCRIPTION
I propose 3 new language options.

When the xAxis is without title, the "xTitle" in the header row of the exported data was always "DateTime" ou "Category".
This commit added two lang options to allow users to translate.
 - Updated : the "Highcharts.setOptions" block and the "getDataRows" function.

Also added a lang option to translate the Excel Worksheet name.
 - Updated : the "Highcharts.setOptions" block and the "downloadXLS" function.

Best regards,