### PR TITLE
Opening new tab for download is not necessary

### DIFF
--- a/export-csv.js
+++ b/export-csv.js
@@ -286,7 +286,6 @@
         } else if (downloadAttrSupported) {
             a = document.createElement('a');
             a.href = href;
-            a.target = '_blank';
             a.download = name + '.' + extension;
             chart.container.append(a); // #111
             a.click();


### PR DESCRIPTION
In Safari 10.1, `target="_blank"` won't make the browser download the file, instead, it opens the file in a new tab. I don't see any reason to include this `target="_blank"` with `download` attribute. So proposing to remove it.